### PR TITLE
商品情報編集機能の記述

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,6 @@
 class ItemsController < ApplicationController
+  before_action :set_item, only: [:edit, :update, :show]
+
   def index
     @items = Item.all.order("created_at DESC")
     
@@ -19,17 +21,17 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    item = Item.find(params[:id])
-    item.update(item_paramas)
-    redirect_to item_path
+    if @item.update(item_paramas)
+      redirect_to item_path
+    else
+      render :edit
+    end
   end
 
   def checked
@@ -46,7 +48,12 @@ class ItemsController < ApplicationController
 
   private
   def item_paramas
-    params.require(:item).permit(:name, :image, :introduction, :category, :item_condition, :delivery_fee, :shipping_area, :shipping_days, :user,:category_id, :item_condition_id, :shipping_days_id, :shipping_area_id, :delivery_fee_id, :price,).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :image, :introduction, :category, :item_condition, :delivery_fee, :shipping_area, :shipping_days, :user,:category_id, :item_condition_id, :shipping_days_id, :shipping_area_id, :delivery_fee_id, :price).merge(user_id: current_user.id)
+
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,7 +20,16 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
-    
+  end
+
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    item = Item.find(params[:id])
+    item.update(item_paramas)
+    redirect_to item_path
   end
 
   def checked

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -83,7 +83,7 @@ app/assets/stylesheets/items/new.css %>
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_days_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_days_id, ShippingDays.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,8 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          
+          <input class="price-input", id="item-price", placeholder="半角数字で入力" type="text" name="item[price]">
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -140,7 +141,7 @@ app/assets/stylesheets/items/new.css %>
     <%# /注意書き %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
+      <%= f.submit "変更する", class:"sell-btn" %>
       <%=link_to 'もどる', "#", class:"back-btn" %>
     </div>
     <%# /下部ボタン %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
 
     <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物であるとき表示しましょう。 %>
   <% if user_signed_in? && current_user.id == @item.user_id  %>
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+    <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
   <% else%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
   get 'items/id', to: 'items#checked'
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
   
 
   


### PR DESCRIPTION
商品情報編集機能の実装。出品したアイテムの内容変更をできるように行いました。
商品情報（商品画像・商品名・商品の状態など）を変更できること
- 出品者だけが編集ページに遷移できること
- 商品出品時とほぼ同じUIで編集機能が実装できること
- 商品名やカテゴリーの情報など、すでに登録されている商品情報は編集画面を開いた時点で表示されること
キャプチャのURLです。
https://gyazo.com/095407d5199a8fcc362a930badfde82f
https://gyazo.com/f4d103fd3bff9b509ac55a55fa9dce25
https://gyazo.com/99302f23a54b32cd098b509c6d1e729c
コードレビューよろしくお願いします。